### PR TITLE
fix: Solve the "Type error: A Bytes-Like Object Is Required, Not ‘str’" encountered when running pssh-box.py

### DIFF
--- a/packager/tools/pssh/pssh-box.py
+++ b/packager/tools/pssh/pssh-box.py
@@ -167,7 +167,7 @@ def _generate_widevine_data(key_ids, content_id, provider, protection_scheme):
     wv.content_id = content_id
   # 'cenc' is the default, so omitted to save bytes.
   if protection_scheme and protection_scheme != 'cenc':
-    wv.protection_scheme = struct.unpack('>L', bytes(protection_scheme, encoding='utf-8'))[0]
+    wv.protection_scheme = struct.unpack('>L', protection_scheme.encode())[0]
   return wv.SerializeToString()
 
 

--- a/packager/tools/pssh/pssh-box.py
+++ b/packager/tools/pssh/pssh-box.py
@@ -167,7 +167,7 @@ def _generate_widevine_data(key_ids, content_id, provider, protection_scheme):
     wv.content_id = content_id
   # 'cenc' is the default, so omitted to save bytes.
   if protection_scheme and protection_scheme != 'cenc':
-    wv.protection_scheme = struct.unpack('>L', protection_scheme)[0]
+    wv.protection_scheme = struct.unpack('>L', bytes(protection_scheme, encoding='utf-8'))[0]
   return wv.SerializeToString()
 
 


### PR DESCRIPTION
A single-line change on #L170 to wv.protection_scheme = struct.unpack('>L', bytes(protection_scheme, encoding='utf-8'))[0], needed to work around this issue on Ubuntu 22.04LTS+ running Python 3.10+:

TypeError: a bytes-like object is required, not 'str'

On line 170.
